### PR TITLE
Carousel Configurator: Fix inert + paged combo

### DIFF
--- a/carousel-configurator/src/components/Configurator.svelte
+++ b/carousel-configurator/src/components/Configurator.svelte
@@ -182,7 +182,7 @@
   }
 }
 `}</code></pre>{/if}
-      {#if paged === 'Yes'}<pre><code>{`.carousel {
+      {#if paged === 'Yes'}<pre><code>{`.carousel--inert {
   [tabindex] {
     animation: offscreen-inert linear both;
     animation-timeline: view(x);

--- a/carousel-configurator/src/components/Configurator.svelte
+++ b/carousel-configurator/src/components/Configurator.svelte
@@ -202,9 +202,11 @@
 </div>
 
 {@html `<style>${`
-  .carousel--inert .card {
+  .carousel--inert {
     transition: opacity .5s ease;
+  }
 
+  .carousel--inert:not(.carousel--paged) .card {
     @container not scroll-state(snapped) {
       interactivity: inert;
       opacity: .25;
@@ -219,9 +221,11 @@
   @keyframes offscreen-inert {
     entry 0%, exit 100% {
       interactivity: inert;
+      opacity: .25;
     }
     entry 100%, exit 0% {
       interactivity: auto;
+      opacity: 1;
     }
   }
 }`}</style>`}


### PR DESCRIPTION
Carousel Configurator: When flipping on both paged and inert, all items have their opacity set to `0.25` which is incorrect. Only the columns that are not in-view should get that.

This PR fixes that + also fixes the class in the preview code.