### PR TITLE
Carousel Configurator: Better tabbing behavior

### DIFF
--- a/carousel-configurator/src/components/Configurator.svelte
+++ b/carousel-configurator/src/components/Configurator.svelte
@@ -184,7 +184,7 @@
 }
 `}</code></pre>{/if}
       {#if paged === 'Yes'}<pre><code>{`.carousel--inert {
-  [tabindex] {
+  > .carousel__slide {
     animation: offscreen-inert linear both;
     animation-timeline: view(x);
   }


### PR DESCRIPTION
We had some UX feedback that one shouldn’t be able to tab through all items in the list but only onto the list (when none of the contained items have focusable content). This PR fixes that by setting the `tabindex=0` onto the entire list instead of each individual item.