### PR TITLE
Carousel Configurator: Update classes in the markup when flipping switches

### DIFF
--- a/carousel-configurator/src/components/Configurator.svelte
+++ b/carousel-configurator/src/components/Configurator.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <section>
-  <pre><code>{`<div class="carousel">
+  <pre><code>{`<div class="carousel`}{#if buttons === 'Yes'} carousel--scroll-buttons{/if}{#if dots === 'Yes'} carousel--scroll-markers{/if}{#if inerted === 'Yes'} carousel--inert{/if}{`">
   <div class="carousel__slide" data-label="Slide 1">…</div>
   <div class="carousel__slide" data-label="Slide 2">…</div>
   <div class="carousel__slide" data-label="Slide 3">…</div>
@@ -182,7 +182,7 @@
   }
 }
 `}</code></pre>{/if}
-      {#if paged === 'Yes'}<pre><code>{`.carousel {
+      {#if paged === 'Yes'}<pre><code>{`.carousel--inert {
   [tabindex] {
     animation: offscreen-inert linear both;
     animation-timeline: view(x);


### PR DESCRIPTION
When flipping on the various switches in the carousel configurator, you conditionally get to see extra CSS to use. This CSS uses specific classes like `.carousel--scroll-markers`. The markup at the top however does not (conditionally) include these classes.

This PR fixes that.