### PR TITLE
Carousel Configurator: Remove unnecessary tabindex=0

### DIFF
--- a/carousel-configurator/src/components/Configurator.svelte
+++ b/carousel-configurator/src/components/Configurator.svelte
@@ -31,7 +31,6 @@
   class:carousel--paged={paged === 'Yes'}
   class:carousel--inert={inerted === 'Yes'}
   class:carousel--forcestop={forcestop === 'Yes'}
-  tabindex=0
 >
   <div class="carousel__slide" data-label="Slide 1">
     <div class="card">1</div>


### PR DESCRIPTION
The scroller is focusable without it.