### PR TITLE
Improvements to screen reader experience on app switcher

### DIFF
--- a/carousels-gallery/src/pages/horizontal/app-switcher.astro
+++ b/carousels-gallery/src/pages/horizontal/app-switcher.astro
@@ -19,80 +19,80 @@ import Layout from "../../layouts/Layout.astro";
     </header>
 
     <div role="region" aria-label="App Switcher carousel demo">
-      <div class="carousel carousel--scroll-buttons carousel--offscreen-inert" aria-live="polite">
-        <div class="carousel__slide item">
-          <figure>
-            <img
-              src="https://assets.codepen.io/2585/1.jpg"
-              alt="A stylized illustration of a pink and blue origami-like figure on a peach-colored background with subtle shadows"
-            />
-          </figure>
-        </div>
-        <div class="carousel__slide item">
-          <figure>
-            <img
-              src="https://assets.codepen.io/2585/2.avif"
-              alt="A stylized illustration of a couple walking in the rain, holding an umbrella, against a city backdrop with warm tones and rain."
-            />
-          </figure>
-        </div>
-        <div class="carousel__slide item">
-          <figure>
-            <img
-              src="https://assets.codepen.io/2585/3.avif"
-              alt="A minimalist cartoonish rendering of a light green turtle on a peach-colored background."
-            />
-          </figure>
-        </div>
-        <div class="carousel__slide item">
-          <figure>
-            <img
-              src="https://assets.codepen.io/2585/4.avif"
-              alt="A detailed close-up of large, blue and white flowers with visible textures and soft lighting."
-            />
-          </figure>
-        </div>
-        <div class="carousel__slide item">
-          <figure>
-            <img
-              src="https://assets.codepen.io/2585/5.avif"
-              alt="A cartoonish illustration of a bright purple cup with orange handle and rim on a peach background."
-            />
-          </figure>
-        </div>
-        <div class="carousel__slide item">
-          <figure>
-            <img
-              src="https://assets.codepen.io/2585/6.avif"
-              alt="A stylized illustration of a beach scene at sunset, with people on the shore, palm trees, and a warm sky gradient."
-            />
-          </figure>
-        </div>
-        <div class="carousel__slide item">
-          <figure>
-            <img
-              src="https://assets.codepen.io/2585/7.avif"
-              alt="A stylized illustration of two people sitting on swings suspended from a tree at a beach during sunset."
-            />
-          </figure>
-        </div>
-        <div class="carousel__slide item">
-          <figure>
-            <img
-              src="https://assets.codepen.io/2585/8.avif"
-              alt="A cartoonish figure of a security guard in uniform, wearing dark glasses, standing with a small suitcase on a turquoise background."
-            />
-          </figure>
-        </div>
-        <div class="carousel__slide item">
+      <ul class="carousel carousel--scroll-buttons">
+        <li class="carousel__slide item">
           <figure>
             <img
               src="https://assets.codepen.io/2585/9.avif"
               alt="A minimalist depiction of a white abstract object, possibly a bowl, on a red background with soft lighting."
             />
           </figure>
-        </div>
-      </div>
+        </li>
+        <li class="carousel__slide item">
+          <figure>
+            <img
+              src="https://assets.codepen.io/2585/8.avif"
+              alt="A cartoonish figure of a security guard in uniform, wearing dark glasses, standing with a small suitcase on a turquoise background."
+            />
+          </figure>
+        </li>
+        <li class="carousel__slide item">
+          <figure>
+            <img
+              src="https://assets.codepen.io/2585/7.avif"
+              alt="A stylized illustration of two people sitting on swings suspended from a tree at a beach during sunset."
+            />
+          </figure>
+        </li>
+        <li class="carousel__slide item">
+          <figure>
+            <img
+              src="https://assets.codepen.io/2585/6.avif"
+              alt="A stylized illustration of a beach scene at sunset, with people on the shore, palm trees, and a warm sky gradient."
+            />
+          </figure>
+        </li>
+        <li class="carousel__slide item">
+          <figure>
+            <img
+              src="https://assets.codepen.io/2585/5.avif"
+              alt="A cartoonish illustration of a bright purple cup with orange handle and rim on a peach background."
+            />
+          </figure>
+        </li>
+        <li class="carousel__slide item">
+          <figure>
+            <img
+              src="https://assets.codepen.io/2585/4.avif"
+              alt="A detailed close-up of large, blue and white flowers with visible textures and soft lighting."
+            />
+          </figure>
+        </li>
+        <li class="carousel__slide item">
+          <figure>
+            <img
+              src="https://assets.codepen.io/2585/3.avif"
+              alt="A minimalist cartoonish rendering of a light green turtle on a peach-colored background."
+            />
+          </figure>
+        </li>
+        <li class="carousel__slide item">
+          <figure>
+            <img
+              src="https://assets.codepen.io/2585/2.avif"
+              alt="A stylized illustration of a couple walking in the rain, holding an umbrella, against a city backdrop with warm tones and rain."
+            />
+          </figure>
+        </li>
+        <li class="carousel__slide item">
+          <figure>
+            <img
+              src="https://assets.codepen.io/2585/1.jpg"
+              alt="A stylized illustration of a pink and blue origami-like figure on a peach-colored background with subtle shadows"
+            />
+          </figure>
+        </li>
+      </ul>
     </div>
   </section>
 
@@ -134,12 +134,10 @@ import Layout from "../../layouts/Layout.astro";
       }
 
       &::before {
-        order: 0;
         inline-size: 25cqi;
       }
 
       &::after {
-        order: 11;
         inline-size: 90cqi;
       }
 
@@ -158,40 +156,31 @@ import Layout from "../../layouts/Layout.astro";
         padding-inline-start: var(--size-2);
 
         &:nth-child(1) {
-          order: 10;
-          z-index: 1;
+          z-index: 9;
         }
         &:nth-child(2) {
-          order: 9;
-          z-index: 2;
+          z-index: 8;
         }
         &:nth-child(3) {
-          order: 8;
-          z-index: 3;
+          z-index: 7;
         }
         &:nth-child(4) {
-          order: 7;
-          z-index: 4;
+          z-index: 6;
         }
         &:nth-child(5) {
-          order: 6;
           z-index: 5;
         }
         &:nth-child(6) {
-          order: 5;
-          z-index: 6;
+          z-index: 4;
         }
         &:nth-child(7) {
-          order: 4;
-          z-index: 7;
+          z-index: 3;
         }
         &:nth-child(8) {
-          order: 3;
-          z-index: 8;
+          z-index: 2;
         }
         &:nth-child(9) {
-          order: 2;
-          z-index: 9;
+          z-index: 1;
         }
       }
 


### PR DESCRIPTION
- Switch to using a `<ul>` and `<li>` so number of items and current item number are announced.
- Make all items interactive and remove aria-live=polite so that we don't announce items entering the view.
- Switched DOM order to match visual order so that items are enumerated in expected order.