### PR TITLE
Add Liquid Glass Components to awesome-html-in-canvas

### DIFF
--- a/html-in-canvas/awesome-html-in-canvas.md
+++ b/html-in-canvas/awesome-html-in-canvas.md
@@ -13,6 +13,7 @@ This is a curated list of links to awesome HTML-in-canvas demos created by the e
 | [Wobble Buttons](https://x.com/wesbos/status/2041974552478052507) | Interactive ripple-effect buttons | [Wes Bos](https://github.com/wesbos) | [Source](https://github.com/wesbos/hot-tips/blob/main/html-in-canvas/demos/wicg/ripple-buttons.html) |
 | [Compiz Web](https://compiz-web.vercel.app/) | Shader-driven web page transitions demo | [Max Leiter](https://github.com/MaxLeiter) | [Source](https://github.com/MaxLeiter/compiz-web) |
 | [HTML cloth](https://arrival.space/htmlcanvas) | Customize a form on a hanging cloth inside a game | [Thomas Richter-Trummer](https://github.com/fimbox) | [Source](https://github.com/fimbox/html-in-canvas/blob/main/plugins/html-cloth.mjs) |
+| [Liquid Glass Components](https://hic-liquid-glass.pages.dev) | Apple-style refractive glass UI components (switch, slider) rendered with WebGL and GLSL shaders on top of HTML-in-Canvas | [Johann Berger](https://github.com/JohnDeved) | [Source](https://github.com/JohnDeved/hic-liquid-glass) |
 | More | demos | coming | soon... |
 
 ## Framework Support 

--- a/html-in-canvas/awesome-html-in-canvas.md
+++ b/html-in-canvas/awesome-html-in-canvas.md
@@ -13,7 +13,7 @@ This is a curated list of links to awesome HTML-in-canvas demos created by the e
 | [Wobble Buttons](https://x.com/wesbos/status/2041974552478052507) | Interactive ripple-effect buttons | [Wes Bos](https://github.com/wesbos) | [Source](https://github.com/wesbos/hot-tips/blob/main/html-in-canvas/demos/wicg/ripple-buttons.html) |
 | [Compiz Web](https://compiz-web.vercel.app/) | Shader-driven web page transitions demo | [Max Leiter](https://github.com/MaxLeiter) | [Source](https://github.com/MaxLeiter/compiz-web) |
 | [HTML cloth](https://arrival.space/htmlcanvas) | Customize a form on a hanging cloth inside a game | [Thomas Richter-Trummer](https://github.com/fimbox) | [Source](https://github.com/fimbox/html-in-canvas/blob/main/plugins/html-cloth.mjs) |
-| [Liquid Glass Components](https://hic-liquid-glass.pages.dev) | Apple-style refractive glass UI components (switch, slider) rendered with WebGL and GLSL shaders on top of HTML-in-Canvas | [Johann Berger](https://github.com/JohnDeved) | [Source](https://github.com/JohnDeved/hic-liquid-glass) |
+| [Liquid Glass Components](https://hic-liquid-glass.pages.dev) | Apple-style refractive glass UI components | [Johann Berger](https://github.com/JohnDeved) | [Source](https://github.com/JohnDeved/hic-liquid-glass) |
 | More | demos | coming | soon... |
 
 ## Framework Support 


### PR DESCRIPTION
Adds Liquid Glass Components to the awesome-html-in-canvas list.

A take on Apple's Liquid Glass switch and slider in the browser. The thumb refracts live page content underneath it in real time, using HTML-in-Canvas to sample the page into a WebGL texture and a small GLSL shader to bend it through the glass shape.

Live: https://hic-liquid-glass.pages.dev
Source: https://github.com/JohnDeved/hic-liquid-glass

![Liquid Glass switch demo](https://hic-liquid-glass.pages.dev/hero.gif)