### PR TITLE
Add Quest Signal to the HTML-in-Canvas ecosystem demos

### DIFF
--- a/html-in-canvas/awesome-html-in-canvas.md
+++ b/html-in-canvas/awesome-html-in-canvas.md
@@ -14,6 +14,7 @@ This is a curated list of links to awesome HTML-in-canvas demos created by the e
 | [Compiz Web](https://compiz-web.vercel.app/) | Shader-driven web page transitions demo | [Max Leiter](https://github.com/MaxLeiter) | [Source](https://github.com/MaxLeiter/compiz-web) |
 | [HTML cloth](https://arrival.space/htmlcanvas) | Customize a form on a hanging cloth inside a game | [Thomas Richter-Trummer](https://github.com/fimbox) | [Source](https://github.com/fimbox/html-in-canvas/blob/main/plugins/html-cloth.mjs) |
 | [PixiJS HTML Laser](https://pixijs-html-in-canvas.vercel.app) | Interactive landing page that shatters and heals over time | [Zyie](https://github.com/Zyie) | [Source](https://github.com/Zyie/pixijs-html-in-canvas) |
+| [Quest Signal](https://vav-labs.com/case-studies/quest-signal/) | A playable Godot scene with accessible, interactive DOM panels rendered as world-space WebGL textures | [Vav Labs](https://vav-labs.com/) | [Source](https://github.com/Vav-Labs/quest-signal) |
 | More | demos | coming | soon... |
 
 ## Framework Support 


### PR DESCRIPTION
## What changed

Adds Quest Signal to the **HTML-in-Canvas demos by the ecosystem** table with links to the live demo, Vav Labs, and the public source repository.

## Why

Quest Signal demonstrates HTML-in-Canvas in a Godot Web scene: three semantic, interactive DOM panels are uploaded to world-space WebGL textures while retaining browser-managed selection, focus, language metadata, and controls. The bridge is bidirectional, including a native DOM button that creates Godot physics bodies.

## Impact

This changes only the curated external-demo list. It does not add runtime code or framework-support claims to this repository.

## Validation

- Live demo: https://vav-labs.com/case-studies/quest-signal/
- Source: https://github.com/Vav-Labs/quest-signal
- All linked URLs return HTTP 200.
- The hosted demo was tested in Chrome 150 through the HTML-in-Canvas Origin Trial and with the `CanvasDrawElement` flag fallback.

The demo and submitted description are original work by Vav Labs.
